### PR TITLE
Add assistant team endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# MrLister AI Assistants
+
+This project provides an Express server and React client for listing and inventory management.
+
+## Assistant Team Endpoint
+
+A new endpoint `/api/assistants/team-run` allows running a sequence of OpenAI assistants on the same thread. The request body should include an array of steps, each specifying an `assistantName` and optional `instructions`. If no `threadId` is provided, a new thread is created.
+
+Example request:
+```json
+{
+  "steps": [
+    { "assistantName": "inventory-expert" },
+    { "assistantName": "marketing-expert", "instructions": "Focus on Etsy" }
+  ]
+}
+```
+The response includes the `threadId` used and an array of assistant messages returned from each step.

--- a/server/ai-assistants.ts
+++ b/server/ai-assistants.ts
@@ -351,6 +351,25 @@ export async function runAssistantOnThread(
 }
 
 /**
+ * Run multiple assistants sequentially on the same thread
+ */
+export async function runAssistantTeam(
+  threadId: string,
+  steps: { assistantName: string; instructions?: string }[]
+) {
+  const responses = [] as any[];
+  for (const step of steps) {
+    const resp = await runAssistantOnThread(
+      step.assistantName,
+      threadId,
+      step.instructions
+    );
+    responses.push(resp);
+  }
+  return responses;
+}
+
+/**
  * Get all messages from a thread
  */
 export async function getThreadMessages(threadId: string) {


### PR DESCRIPTION
## Summary
- add README with details about new assistant team route
- support running a team of assistants in `ai-assistants.ts`
- expose `/api/assistants/team-run` API route

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68456b8cc8308328b567cb020803d6ee